### PR TITLE
Use Array#slice instead of TypedArray#slice for Safari compatibility

### DIFF
--- a/grid-index.js
+++ b/grid-index.js
@@ -71,7 +71,7 @@ GridIndex.prototype.query = function(x1, y1, x2, y2) {
     var min = this.min;
     var max = this.max;
     if (x1 <= min && y1 <= min && max <= x2 && max <= y2) {
-        return this.keys.slice();
+        return Array.prototype.slice.call(this.keys);
 
     } else {
         var result = [];

--- a/grid-index.js
+++ b/grid-index.js
@@ -71,6 +71,9 @@ GridIndex.prototype.query = function(x1, y1, x2, y2) {
     var min = this.min;
     var max = this.max;
     if (x1 <= min && y1 <= min && max <= x2 && max <= y2) {
+        // We use `Array#slice` because `this.keys` may be a `Int32Array` and
+        // some browsers (Safari and IE) do not support `TypedArray#slice`
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice#Browser_compatibility
         return Array.prototype.slice.call(this.keys);
 
     } else {


### PR DESCRIPTION
fixes https://github.com/mapbox/mapbox-gl-js/issues/2822

Root cause: Safari does not support `TypedArray.prototype.slice()`: [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice#Browser_compatibility)

This PR uses `Array.prototype.slice.call(…)` instead to ensure Safari and IE compatibility. 

cc @jfirebaugh @ansis @mourner 

# Next Steps

 - [x] get a :shipit: on this PR
 - [ ] merge this PR
 - [ ] publish a new version of `grid-index` on npm
 - [ ] update `package.json` in GL JS to use the new version